### PR TITLE
fix: [FTL-8266] Changed order of Home page buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21098,7 +21098,7 @@
         "css-what": "^6.0.1",
         "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
-        "nth-check": "2.1.1"
+        "nth-check": "^2.0.1"
       }
     },
     "css-select-base-adapter": {
@@ -27116,7 +27116,7 @@
             "boolbase": "^1.0.0",
             "css-what": "^3.2.1",
             "domutils": "^1.7.0",
-            "nth-check": "2.1.1"
+            "nth-check": "^1.0.2"
           }
         },
         "css-what": {

--- a/src/components/Authorisation/AuthRoute.tsx
+++ b/src/components/Authorisation/AuthRoute.tsx
@@ -9,7 +9,7 @@ export const AuthRoute: FC = ({ children }) => {
 
   const isIssuer = location.pathname.includes('/issuer')
 
-  if ((isIssuer && authState.authorizedAsIssuer) || authState.authorizedAsHolder) {
+  if ((isIssuer && authState.authorizedAsIssuer) || (!isIssuer && authState.authorizedAsHolder)) {
     return <>{children}</>
   }
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -17,6 +17,19 @@ export const Home: FC = () => {
       <Container isHome title="Please select one of the following options">
         <S.Card
           onClick={() => {
+            updateAuthState({ appFlow: 'issuer' })
+            navigate(PATHS.ISSUER.CREDENTIAL_FORM)
+          }}
+        >
+          <S.Details>
+            <S.Heading variant="h7">Issue credential</S.Heading>
+            <S.Para variant="p2">Issue credentials to your customers easily</S.Para>
+          </S.Details>
+          <S.Icon src={issuerFlowIcon} />
+        </S.Card>
+
+        <S.Card
+          onClick={() => {
             updateAuthState({ appFlow: 'holder' })
             navigate(PATHS.HOLDER.HOME)
           }}
@@ -41,19 +54,6 @@ export const Home: FC = () => {
             <S.Para variant="p2">Verify credentials with a QR code scanner</S.Para>
           </S.Details>
           <S.Icon src={verifierFlowIcon} />
-        </S.Card>
-
-        <S.Card
-          onClick={() => {
-            updateAuthState({ appFlow: 'issuer' })
-            navigate(PATHS.ISSUER.CREDENTIAL_FORM)
-          }}
-        >
-          <S.Details>
-            <S.Heading variant="h7">Issue credential</S.Heading>
-            <S.Para variant="p2">Issue credentials to your customers easily</S.Para>
-          </S.Details>
-          <S.Icon src={issuerFlowIcon} />
         </S.Card>
       </Container>
     </>


### PR DESCRIPTION
Links to user flows are now in the following order:
ISSUER
HOLDER
VERIFIER

This PR brings in latest `src` folder from Gitlab repo.

All three user flows have been manually smoked-tested with the application running locally.