### PR TITLE
fix: [FTL-8397] Fixed issuer login 

### DIFF
--- a/src/services/user-management/index.ts
+++ b/src/services/user-management/index.ts
@@ -17,7 +17,7 @@ export const isHttpError = (
     message: string
   }
 } => {
-  return Object.prototype.hasOwnProperty.call(error, 'status')
+  return Object.prototype.hasOwnProperty.call(error, 'error')
 }
 
 class UserManagementService {


### PR DESCRIPTION
A one-line fix for a type guard that was failing to allow subsequent sign-up when logging in with an unknown user